### PR TITLE
Add a colon so that “click to start” doesn’t feel like a button itself

### DIFF
--- a/captcha.html
+++ b/captcha.html
@@ -94,7 +94,7 @@ button{background:none;border:1px #fff solid;color:#fff;cursor:pointer;margin-to
 <div id="start" style="font-size:20px;z-index:4;color:white;background:black;position:fixed;left:0;top:0;width:100%;height:100%;display:flex;text-align:center;justify-content: center;align-items: center;">
     <div>
         <div style="display:block;color:red">kill <span id="max_kills" style="color:red">4</span> enemies</div>
-        click to start
+        click to start:
         <br>
         <button id="btn_start"><svg style="margin-bottom:-7px;margin-right:10px;" xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" class="bi bi-volume-up-fill" viewBox="0 0 16 16">
             <path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.473 0 0 0-2.49-6.01l-.708.707A7.476 7.476 0 0 1 13.025 8c0 2.071-.84 3.946-2.197 5.303l.708.707z"/>


### PR DESCRIPTION
Congrats on the launch!

As pointed out by SmartHypercube on HN [1], “click to start” can feel like a button you want to press. You can help that by adding a colon, prompting the user to choose from two options:

<img src="https://github.com/vivirenremoto/doomcaptcha/assets/1298948/504ffb9d-5b55-4438-bf94-f46f626e7e20" width="304" />

(You may also want to tweak margins on the buttons to make them a bit closer, perhaps?)

[1]: https://news.ycombinator.com/item?id=39860187 – a bit mean if you ask me, but I think the concern is valid